### PR TITLE
Potential fix for code scanning alert no. 15: DOM text reinterpreted as HTML

### DIFF
--- a/phpBB/styles/prosilver/template/forum_fn.js
+++ b/phpBB/styles/prosilver/template/forum_fn.js
@@ -5,6 +5,20 @@
 */
 
 /**
+* Escape HTML special characters
+*/
+function escapeHtml(text) {
+	var map = {
+		'&': '&amp;',
+		'<': '&lt;',
+		'>': '&gt;',
+		'"': '&quot;',
+		"'": '&#039;'
+	};
+	return text.replace(/[&<>"']/g, function(m) { return map[m]; });
+}
+
+/**
 * Find a member
 */
 function find_username(url) {
@@ -599,7 +613,7 @@ function parseDocument($container) {
 				}
 
 				if ((text.length && text !== '-') || cell.children().length) {
-					cell.prepend('<dfn style="display: none;">' + headers[column] + '</dfn>');
+					cell.prepend('<dfn style="display: none;">' + escapeHtml(headers[column]) + '</dfn>');
 				} else {
 					cell.addClass('empty');
 				}


### PR DESCRIPTION
Potential fix for [https://github.com/securityuniverse/phpbb/security/code-scanning/15](https://github.com/securityuniverse/phpbb/security/code-scanning/15)

To fix the problem, we need to ensure that any text content derived from the DOM and used in HTML is properly escaped to prevent XSS attacks. The best way to fix this issue is to use a function that escapes HTML special characters before concatenating the text into the HTML string.

We will:
1. Create a function to escape HTML special characters.
2. Use this function to escape the content of `headers[column]` before concatenating it into the HTML string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
